### PR TITLE
Ignore major version updates for mobx

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,9 @@ updates:
   schedule:
     interval: weekly
   open-pull-requests-limit: 10
+  ignore:
+    - dependency-name: mobx
+      update-types: [ version-update:semver-major ]
 
 - package-ecosystem: github-actions
   directory: /


### PR DESCRIPTION
This library will only be compatible with a specific major version of mobx, so dependabot should ignore those updates.